### PR TITLE
Choice nodes, variables management & node connections

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -24,9 +24,11 @@
 
   let editPanelRef: HTMLDivElement | null = null;
 
+  export let isGlobalMode: boolean = true;
+
   function handleContextMenu({ detail: { event, node } }) {
     event.preventDefault();
-
+    isGlobalMode = false;
     menu = {
       id: node.id,
       top: event.clientY < height - 200 ? event.clientY : undefined,
@@ -57,6 +59,7 @@
     }
     else {
       menu = null;
+      isGlobalMode = true;
     if (editPanelRef && !editPanelRef.contains(event.target as Node) && !target) {
       editPanel = null;
     }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4,10 +4,13 @@
   import '@xyflow/svelte/dist/style.css';
   import StoryNode from './StoryNode.svelte';
   import NodeMenu from './NodeMenu.svelte';
-  import { Navbar, Button, TabItem, ToolbarGroup} from 'flowbite-svelte';
-  import type { Writable } from 'svelte/store';
+  import { Navbar, Button} from 'flowbite-svelte';
+  import { type Writable } from 'svelte/store';
   import NodeEditPanel from './NodeEditPanel.svelte';
   import { nodes, edges } from './stores';
+	import { onMount } from 'svelte';
+  import { nodeRefs } from './stores';
+	import VariablePanel from './VariablePanel.svelte';
 
   const nodeTypes = {
     'story-node': StoryNode
@@ -21,7 +24,6 @@
 
   let editPanelRef: HTMLDivElement | null = null;
 
-
   function handleContextMenu({ detail: { event, node } }) {
     event.preventDefault();
 
@@ -34,14 +36,37 @@
     };
   }
 
-  function handlePaneClick({ detail: { event } }) {
-    menu = null;
-    let mouseEvent = event as MouseEvent;
-    if (editPanelRef && !editPanelRef.contains(mouseEvent.target as Node)) {
+  function handlePaneClick(event: MouseEvent) {
+    //event.preventDefault();
+    let target = event.target as HTMLElement;
+    if(event.button === 2){
+      nodeRefs.subscribe(refs => {
+        const nodeRef = refs.find(ref => {
+          return ref.nodeRef?.contains(event.target as Node);
+        });
+        if (!nodeRef) {
+          menu = {
+      id: '0',
+      top: event.clientY < height - 200 ? event.clientY : undefined,
+      left: event.clientX < width - 200 ? event.clientX : undefined,
+      right: event.clientX >= width - 200 ? width - event.clientX : undefined,
+      bottom: event.clientY >= height - 200 ? height - event.clientY : undefined
+    };
+      }
+    })
+    }
+    else {
+      menu = null;
+    if (editPanelRef && !editPanelRef.contains(event.target as Node) && !target) {
       editPanel = null;
+    }
     }
     
   }
+
+  onMount(() => {
+    document.addEventListener('contextmenu', handlePaneClick);
+  });
 
   function handleEditNode(event) {
     const { id, title, delta, content, color } = event.detail;
@@ -50,7 +75,6 @@
 
 </script>
 
-  
   <div id="pageBody">
         <div class="relative px-8">
             <Navbar class="px-2 sm:px-4 py-2.5 fixed w-full z-20 top-0 start-0 border-b">
@@ -64,7 +88,7 @@
           </div>
     <div id="svelteCanvas" bind:clientWidth={width} bind:clientHeight={height}>
       <SvelteFlow {nodes} {edges} {nodeTypes} colorMode="dark" on:nodecontextmenu={handleContextMenu}
-      on:paneclick={handlePaneClick} fitView>
+      on:paneclick={(event) => handlePaneClick(event)}  on:contextmenu={(event) => handlePaneClick(event)} fitView>
         <Background />
         <Controls />
         <MiniMap nodeStrokeWidth={3} pannable/>
@@ -83,6 +107,7 @@
       <NodeEditPanel bind:panelRef={editPanelRef}
       id={editPanel.nodeId} title={editPanel.nodeTitle} deltaInput={editPanel.delta} content={editPanel.content} color={editPanel.color} on:close={() => editPanel = null}/>
           {/if}
+      <VariablePanel/>
       </SvelteFlow>  
     </div>
       </div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,6 +1,6 @@
 
 <script lang="ts">
-  import { SvelteFlow, Background, Controls, MiniMap } from '@xyflow/svelte';
+  import { SvelteFlow, Background, Controls, MiniMap, useEdges } from '@xyflow/svelte';
   import '@xyflow/svelte/dist/style.css';
   import StoryNode from './StoryNode.svelte';
   import ChoiceNode from './ChoiceNode.svelte';
@@ -25,7 +25,6 @@
   let height: number;
 
   let editPanel: {nodeId: string; nodeTitle: Writable<string>; deltaInput: Writable<any>; color: Writable<string>; content: Writable<string>} | null;
-  let editChoicePanel: {nodeId: string; deltaInput: Writable<any>; color: Writable<string>; content: Writable<string>} | null;
 
   let editPanelRef: HTMLDivElement | null = null;
 
@@ -99,10 +98,12 @@
 
   function handleEditNode(event) {
     const { id, title, delta, content, color } = event.detail;
-    if(title == undefined){
-      editChoicePanel = { nodeId: id, deltaInput: delta, content: content, color: color };
-    }
     editPanel = { nodeId: id, nodeTitle: title, deltaInput: delta, content: content, color: color };
+  }
+
+  function deleteEdge(event){
+    const id  = event.detail.edge.id;
+    $edges = $edges.filter((edge) => edge.id !== id);
   }
 
 
@@ -121,7 +122,7 @@
           </div>
     <div id="svelteCanvas" bind:clientWidth={width} bind:clientHeight={height}>
       <SvelteFlow {nodes} {edges} {nodeTypes} colorMode="dark" on:nodecontextmenu={handleContextMenu}
-      on:paneclick={(event) => handlePaneClick(event)}  on:contextmenu={(event) => handlePaneClick(event)} fitView>
+      on:paneclick={(event) => handlePaneClick(event)}  on:contextmenu={(event) => handlePaneClick(event)} fitView defaultEdgeOptions={{deletable: true}} on:edgeclick={deleteEdge}>
         <Background />
         <Controls />
         <MiniMap nodeStrokeWidth={3} pannable/>

--- a/src/routes/ChoiceNode.svelte
+++ b/src/routes/ChoiceNode.svelte
@@ -4,24 +4,16 @@
     import { focusedNodeContent, isGlobalMode, nodeRefs, variables } from './stores';
 	import { onDestroy, onMount } from 'svelte';
     type $Props = NodeProps;
-
-    type Line = {
-    owner: Writable<string>;
-    lineContent: Writable<string>;
-    };
-
     type NodeData = {
-        title: Writable<string>;
         color: Writable<string>;
         content: Writable<string>;
         delta: Writable<any>;
     };
 
     export let data: NodeData;
-    export let localTitle: string = ''; 
     export let localContent: string = ''; 
     export let localDelta: any = {};
-    export let localColor: string = '#ffffff'; 
+    export let localColor: string = '#454545'; 
     export let selected: $Props['selected'] = undefined;
 
 
@@ -34,7 +26,6 @@
 });
 
     $: {
-        data.title.subscribe(value => localTitle = value);
         data.color.subscribe(value => localColor = value);
         data.content.subscribe(value => localContent = value);
         data.delta.subscribe(value => localDelta = value);
@@ -68,15 +59,14 @@
 
   </script>
    
-  <div class="storynode" style="background-color: {localColor}"  bind:this={nodeRef} on:click={() => {isGlobalMode.set(false);
+  <div class="choicenode" style="background-color: {localColor}"  bind:this={nodeRef} on:click={() => {isGlobalMode.set(false);
     focusedNodeContent.set(get(data.content));
     setCurrentValues();
   }}>
     <NodeResizer minWidth={100} minHeight={100} isVisible={selected} />
     <Handle type="target" position={Position.Top} />
     <div>
-    title: <strong>{localTitle}</strong><br>
-    <div class="storynode__content">
+    <div class="choicenode__content">
       {@html localContent}
     </div>
     </div>
@@ -84,13 +74,13 @@
   </div>
 
   <style>
-    .storynode {
+    .choicenode {
       padding: 10px;
       width: 100%;
       height: 100%;
     }
     
-    .storynode__content {
+    .choicenode__content {
       white-space: pre-wrap;
     }
   </style>

--- a/src/routes/ConditionSetter.svelte
+++ b/src/routes/ConditionSetter.svelte
@@ -1,0 +1,167 @@
+<script lang="ts">
+
+	import { Button, Input, Label, Radio, Select, Table, TableBody, TableBodyCell, TableBodyRow } from "flowbite-svelte";
+	import { get } from "svelte/store";
+	import { conditions, variables } from "./stores";
+	import type { Condition } from "./stores";
+
+    function createCondition(number: number, var1Type: string, var1: any, comparision: string, var2Type: string, var2: any, funcArgs1: Array<any>, funcArgs2: Array<any>, logicOp?: string){
+        return {
+          number: number,  
+          var1Type: var1Type, 
+          var1: var1, 
+          comparison: comparision, 
+          var2Type: var2Type,  
+          var2: var2,
+          funcArgs1: funcArgs1,
+          funcArgs2: funcArgs2,
+          logicOp: logicOp
+        }
+        }
+        function addCondition(condition: Condition){
+          conditions.update((currentArray) => {
+          currentArray.push(condition);
+          return currentArray;
+	});
+        }
+        if($conditions.length == 0){
+        addCondition(createCondition(1,"variable",null,"","variable",null,[],[]));
+        }
+
+        function deleteCondition(condition: Condition){
+        conditions.update(currentArray => {
+            return currentArray.filter(c => c !== condition);
+        });
+    }
+
+</script>
+<Table striped={true}>
+    <TableBody tableBodyClass="divide-y">
+    {#each $conditions as condition, i}
+    <TableBodyRow>
+    <TableBodyCell>Condition {i+1}:</TableBodyCell>
+    <TableBodyCell><Label for="small-input">Variable/Function: </Label>
+      <Label>Variable </Label><Radio checked={condition.var1Type === 'variable'} name="funcVarValue1Con{i+1}" value="variable" bind:group={condition.var1Type}/>
+      <Label>Function </Label><Radio checked={condition.var1Type === 'function'} name="funcVarValue1Con{i+1}" value="function" bind:group={condition.var1Type}/>
+    </TableBodyCell>
+    {#if condition.var1Type == "variable"}
+    <TableBodyCell>
+      <Select bind:value={condition.var1}>
+        {#each get(variables) as variable}
+        <option value="{variable}">{get(variable.name)}</option> 
+        {/each}
+    </Select>
+    </TableBodyCell>
+    {:else}
+    <TableBodyCell>
+      <Select bind:value={condition.var1}>
+        <option value="visited">visited(node_name)</option>
+        <option value="visitedCount">visited_count(node_name)</option>
+        <option value="random">random()</option>
+        <option value="randomRange">random_range(num1,num2)</option>  
+        <option value="dice">dice(numOfSides)</option>  
+        <option value="inc">inc(num)</option>
+        <option value="dec">dec(num)</option>
+    </Select>
+    </TableBodyCell>
+    {#if condition.var1 == "visited" || condition.var1 == "visitedCount"}
+    <TableBodyCell>
+      <Label for="small-input">Node name: </Label><Input size="sm" style="" type="text" bind:value={condition.funcArgs1[0]}/>
+    </TableBodyCell>
+    {:else if condition.var1 == "dice" || condition.var1 == "inc" || condition.var1 == "dec"}
+    <TableBodyCell>
+      <Label for="small-input">Number: </Label><Input size="sm" style="" type="number" bind:value={condition.funcArgs1[0]}/>
+    </TableBodyCell>
+    {:else if condition.var1 == "randomRange"}
+    <TableBodyCell>
+      <Label for="small-input">From: </Label><Input size="sm" style="" type="number" bind:value={condition.funcArgs1[0]}/>
+      <Label for="small-input">To: </Label><Input size="sm" style="" type="number" bind:value={condition.funcArgs1[1]}/>
+    </TableBodyCell>
+    {/if}
+    {/if}
+    <TableBodyCell>
+      <Select bind:value={condition.comparison}>
+        <option value="<">less than</option>
+        <option value="<=">less or equal to</option> 
+        <option value="==">equal to</option> 
+        <option value="!=">not equal to</option>
+        <option value=">">more than</option>
+        <option value=">=">more or equal to</option>   
+    </Select>
+    </TableBodyCell>
+    {#if condition.comparison != ""}
+    <TableBodyCell>
+      <Label>Variable </Label><Radio checked={condition.var2Type === 'variable'} name="funcVarValue2Con{i+1}" value="variable" bind:group={condition.var2Type}/>
+      <Label>Function </Label><Radio checked={condition.var2Type === 'function'} name="funcVarValue2Con{i+1}" value="function" bind:group={condition.var2Type}/>
+      <Label>Value </Label><Radio checked={condition.var2Type === 'value'} name="funcVarValue2Con{i+1}" value="value" bind:group={condition.var2Type}/>
+    </TableBodyCell>
+      {#if condition.var2Type == "variable"}
+      <TableBodyCell>
+        <Select bind:value={condition.var2}>
+          {#each get(variables) as variable}
+          {#if condition.var1 != null && get(variable.name) != get(condition.var1.name)  && get(variable.type) == get(condition.var1.type)}
+          <option value="{get(variable.name)}">{get(variable.name)}</option> 
+          {/if}
+          {/each}
+      </Select>
+      </TableBodyCell>
+      {:else if condition.var2Type == "function"}
+      <TableBodyCell>
+        <Select bind:value={condition.var2}>
+          <option value="visited">visited(node_name)</option>
+          <option value="visitedCount">visited_count(node_name)</option>
+          <option value="random">random()</option>
+          <option value="randomRange">random_range(num1,num2)</option>  
+          <option value="dice">dice(numOfSides)</option>  
+          <option value="inc">inc(num)</option>
+          <option value="dec">dec(num)</option>
+      </Select>
+      </TableBodyCell>
+        {#if condition.var2 == "visited" || condition.var2 == "visitedCount"}
+        <TableBodyCell>
+          <Label for="small-input">Node name: </Label><Input size="sm" style="" type="text" bind:value={condition.funcArgs2[0]}/>
+        </TableBodyCell>
+        {:else if condition.var2 == "dice" || condition.var2 == "inc" || condition.var2 == "dec"}
+        <TableBodyCell>
+          <Label for="small-input">Number: </Label><Input size="sm" style="" type="number" bind:value={condition.funcArgs2[0]}/>
+        </TableBodyCell>
+        {:else if condition.var2 == "randomRange"}
+        <TableBodyCell>
+          <Label for="small-input">From: </Label><Input size="sm" style="" type="number" bind:value={condition.funcArgs2[0]}/>
+          <Label for="small-input">To: </Label><Input size="sm" style="" type="number" bind:value={condition.funcArgs2[1]}/>
+        </TableBodyCell>
+        {/if}
+      {:else}
+      {#if condition.var1 != null}
+      <TableBodyCell>
+          {#if get(condition.var1.type) == "number" || condition.var1 == "visitedCount" || condition.var1 == "random" || condition.var1 == "randomRange" || condition.var1 == "dice" || condition.var1 == "inc" || condition.var1 == "dec"}
+          <Label for="small-input">Value: </Label><Input size="sm" type="number" bind:value={condition.var2}/>
+          {:else if get(condition.var1.type) == "text"}
+          <Label for="small-input">Value: </Label><Input size="sm" type="text" bind:value={condition.var2}/>
+          {:else}
+          <Label for="small-input">Value: </Label> 
+          <Label>True </Label><Radio checked={true} name="valRadioCon{i+1}" value="true" bind:group={condition.var2}/>
+          <Label>False </Label><Radio name="valRadioCon{i+1}" value="false" bind:group={condition.var2}/>
+          {/if}
+      </TableBodyCell>
+      {/if}
+      {/if}
+      {/if}
+      {#if condition.number != $conditions.length}
+    <TableBodyCell>
+      <Label>Join conditions: </Label>
+      <Select bind:value={condition.logicOp}>
+        <option value="&&">and</option>
+        <option value="||">or</option>
+    </Select>
+  </TableBodyCell>
+      {/if}
+      <TableBodyCell>
+        <a class="font-medium text-primary-600 hover:underline dark:text-primary-500" on:click={() => deleteCondition(condition)}>Delete</a>
+      </TableBodyCell>
+    </TableBodyRow>
+    {/each}
+    <Button on:click={() => {addCondition(createCondition($conditions.length+1,"",null,"","",null,[],[]));
+    }}>Add condition</Button>
+    </TableBody>
+    </Table>

--- a/src/routes/CustomHandle.svelte
+++ b/src/routes/CustomHandle.svelte
@@ -1,0 +1,63 @@
+<script lang="ts">
+	import { getOutgoers, Handle, Position, type IsValidConnection } from "@xyflow/svelte";
+	import { edges, nodes } from "./stores";
+
+    let isConnectableStart = true;
+    let isConnectableEnd = true;
+    let isValidConnection: IsValidConnection;
+    export let handleType;
+    export let position: Position;
+    export let data;
+
+    function getSourceNode(connection) {
+        const sourceNode = $nodes.find(node => node.id === connection.source);
+            return sourceNode;
+    }
+    function getTargetNode(connection) {
+        const targetNode = $nodes.find(node => node.id === connection.target);
+            return targetNode;
+    }
+
+function updateConnectionStatusOut() {
+    const outgoers = getOutgoers({ id: data.nodeId }, $nodes, $edges);
+        const storyNodeConnectionsOut = outgoers.filter(node => node.type === "story-node").length;
+        const choiceNodeConnectionsOut = outgoers.filter(node => node.type === "choice-node").length;
+        isConnectableEnd = storyNodeConnectionsOut < 1;
+        isValidConnection = (connection) => {
+          const targetNode = getTargetNode(connection);
+          if(targetNode?.type == 'story-node'){
+            return isConnectableEnd && choiceNodeConnectionsOut == 0;
+          }
+          else {
+            return isConnectableEnd;
+          }
+        }
+    }  
+  
+  function updateConnectionStatusIn() {
+     return isValidConnection = (connection) => {
+    const sourceNode = getSourceNode(connection);
+            const SourceOutgoers = sourceNode?.data.outgoers as Node[];
+            const storyNodeConnectionsIn = SourceOutgoers.filter(node => node.type === "story-node").length;
+            const choiceNodeConnectionsIn = SourceOutgoers.filter(node => node.type === "choice-node").length;
+            isConnectableStart = storyNodeConnectionsIn < 1; 
+              if(sourceNode?.type === 'story-node'){
+                return isConnectableStart && choiceNodeConnectionsIn == 0; 
+              }
+              else {
+                return isConnectableStart;
+              }
+            };
+  }
+
+    $: {
+      if ($nodes && $edges && data.nodeId) {
+        if(handleType == "source"){
+            updateConnectionStatusOut();
+        }
+        else updateConnectionStatusIn();
+      }
+    }
+
+</script>
+<Handle type="{handleType}" position={position} isValidConnection={isValidConnection}/>

--- a/src/routes/NodeMenu.svelte
+++ b/src/routes/NodeMenu.svelte
@@ -44,13 +44,21 @@
       if (node) {
        let foundNode = $allNodes.find((node) => parseInt(node.id) == lastId);
        if(foundNode) {
+        let newNode;
         lastId = parseInt(foundNode.id) + 1;
+        if(nodeType == "story-node"){
+       newNode = createNode(
+        nodeType, node.position.x + 100, node.position.y + 100, get(nodeColor), get(nodeDelta), get(nodeContent), get(nodeTitle))
        }
-       const newNode = createNode(
-        nodeType, node.position.x + 100, node.position.y + 100, get(nodeTitle), get(nodeColor), get(nodeDelta), get(nodeContent))
-       
-        $allNodes.push(newNode);
+       else {
+        newNode = createNode(
+        nodeType, node.position.x + 100, node.position.y + 100, get(nodeColor), get(nodeDelta), get(nodeContent))
+        
+       }
+       $allNodes.push(newNode);
+       }
       }
+      
       $allNodes = $allNodes;
     }
     function deleteNode() {
@@ -80,15 +88,21 @@
 
   function addNode(event) {
     if(left && top){
-    const newNode = createNode(event.target.value, 200, 200, 'default-title', '#eeeeee',{}, '');
-    $allNodes.push(newNode);
+      let newNode;
+      if(event.target.value == "story-node"){
+        newNode = createNode(event.target.value, 200, 200, '#eeeeee',{}, '', 'default-title');
+      }
+      else {
+        newNode = createNode(event.target.value, 200, 200, '#454545',{}, '');
+      }
+      $allNodes.push(newNode);
+    
     $allNodes = $allNodes;
     // const { zoomIn, zoomOut, setZoom, fitView, setCenter, setViewport, getViewport, viewport } =
     // useSvelteFlow();
 
     // setViewport({x: left, y: top, zoom: 2});
     }
-
   }
   </script>
   
@@ -99,7 +113,7 @@
   >
     {#if id == '0'}
     <button on:click={(event) => addNode(event)} value="story-node">add story node</button>
-    <button disabled on:click={(event) => addNode(event)} value="choice-node">add choice node</button>
+    <button on:click={(event) => addNode(event)} value="choice-node">add choice node</button>
     {:else}
     <p style="margin: 0.5em;">
       <small>node: {id}</small>

--- a/src/routes/NodeMenu.svelte
+++ b/src/routes/NodeMenu.svelte
@@ -1,12 +1,13 @@
 <script lang="ts">
-    import { useEdges, useNodes, useNodesData } from '@xyflow/svelte';
+    import { useEdges, useNodes, useNodesData, useSvelteFlow } from '@xyflow/svelte';
     import { get, writable, type Writable } from 'svelte/store';
     import NodeData from "./StoryNode.svelte";
     import { createEventDispatcher } from 'svelte';
     import { createNode, nodes } from './stores';
+    import fitView from './+page.svelte';
 
     export let onClick: ({ detail: { event } }) => void;
-    export let id: string;
+    export let id: string = '0';
     export let top: number | undefined;
     export let left: number | undefined;
     export let right: number | undefined;
@@ -76,6 +77,25 @@
 
   }
 }
+
+  function addNode(event) {
+    if(left && top){
+    const newNode = createNode(event.target.value, 200, 200, 'default-title', '#eeeeee',{}, '');
+    $allNodes.push(newNode);
+    $allNodes = $allNodes;
+
+    // const { zoomIn, zoomOut, setZoom, fitView, setCenter, setViewport, getViewport, viewport } =
+    // useSvelteFlow();
+
+   
+
+    // setViewport({x: left, y: top, zoom: 2});
+    
+
+
+    }
+
+  }
   </script>
   
   <div
@@ -83,12 +103,17 @@
     class="context-menu"
     on:click={onClick}
   >
+    {#if id == '0'}
+    <button on:click={(event) => addNode(event)} value="story-node">add story node</button>
+    <button disabled on:click={(event) => addNode(event)} value="choice-node">add choice node</button>
+    {:else}
     <p style="margin: 0.5em;">
       <small>node: {id}</small>
     </p>
     <button on:click={editNode}>edit</button>
     <button on:click={duplicateNode}>duplicate</button>
     <button on:click={deleteNode}>delete</button>
+    {/if}
   </div>
  
   

--- a/src/routes/NodeMenu.svelte
+++ b/src/routes/NodeMenu.svelte
@@ -83,16 +83,10 @@
     const newNode = createNode(event.target.value, 200, 200, 'default-title', '#eeeeee',{}, '');
     $allNodes.push(newNode);
     $allNodes = $allNodes;
-
     // const { zoomIn, zoomOut, setZoom, fitView, setCenter, setViewport, getViewport, viewport } =
     // useSvelteFlow();
 
-   
-
     // setViewport({x: left, y: top, zoom: 2});
-    
-
-
     }
 
   }

--- a/src/routes/StoryNode.svelte
+++ b/src/routes/StoryNode.svelte
@@ -1,18 +1,14 @@
 <script lang="ts">
     import { Handle, Position, NodeResizer, type NodeProps } from '@xyflow/svelte';
     import {type Writable } from 'svelte/store';
+    import { nodeRefs } from './stores';
+	import { onDestroy, onMount } from 'svelte';
     type $Props = NodeProps;
 
     type Line = {
     owner: Writable<string>;
     lineContent: Writable<string>;
     };
-
-    type Variable = {
-      name: Writable<string>;
-      type: Writable<string>;
-      value: Writable<any>;
-    }
 
     type NodeData = {
         title: Writable<string>;
@@ -28,6 +24,15 @@
     export let localColor: string = '#ffffff'; 
     export let selected: $Props['selected'] = undefined;
 
+
+    export let nodeRef: HTMLDivElement | null = null;
+
+    onMount(() => {
+      if(nodeRef){
+  nodeRefs.update(refs => [...refs, { nodeRef }]);
+      }
+});
+
     $: {
         data.title.subscribe(value => localTitle = value);
         data.color.subscribe(value => localColor = value);
@@ -38,7 +43,7 @@
     $$restProps;
   </script>
    
-  <div class="storynode" style="background-color: {localColor}">
+  <div class="storynode" style="background-color: {localColor}"  bind:this={nodeRef}>
     <NodeResizer minWidth={100} minHeight={100} isVisible={selected} />
     <Handle type="target" position={Position.Top} />
     <div>

--- a/src/routes/StoryNode.svelte
+++ b/src/routes/StoryNode.svelte
@@ -1,20 +1,18 @@
 <script lang="ts">
-    import { Handle, Position, NodeResizer, type NodeProps } from '@xyflow/svelte';
+    import { Position, NodeResizer, type NodeProps, getOutgoers} from '@xyflow/svelte';
     import {get, type Writable } from 'svelte/store';
-    import { focusedNodeContent, isGlobalMode, nodeRefs, variables } from './stores';
+    import { edges, focusedNodeContent, isGlobalMode, nodeRefs, nodes, variables } from './stores';
 	import { onDestroy, onMount } from 'svelte';
+	import CustomHandle from './CustomHandle.svelte';
     type $Props = NodeProps;
-
-    type Line = {
-    owner: Writable<string>;
-    lineContent: Writable<string>;
-    };
 
     type NodeData = {
         title: Writable<string>;
         color: Writable<string>;
         content: Writable<string>;
         delta: Writable<any>;
+        nodeId: string;
+        outgoers: Node[];
     };
 
     export let data: NodeData;
@@ -24,8 +22,8 @@
     export let localColor: string = '#ffffff'; 
     export let selected: $Props['selected'] = undefined;
 
-
     export let nodeRef: HTMLDivElement | null = null;
+
 
     onMount(() => {
       if(nodeRef){
@@ -38,6 +36,7 @@
         data.color.subscribe(value => localColor = value);
         data.content.subscribe(value => localContent = value);
         data.delta.subscribe(value => localDelta = value);
+        data.outgoers = getOutgoers({ id: data.nodeId }, $nodes, $edges);
     }
 
     $$restProps;
@@ -65,7 +64,6 @@
         focusedNodeContent.set(get(data.content));
         setCurrentValues();
     }
-
   </script>
    
   <div class="storynode" style="background-color: {localColor}"  bind:this={nodeRef} on:click={() => {isGlobalMode.set(false);
@@ -73,14 +71,16 @@
     setCurrentValues();
   }}>
     <NodeResizer minWidth={100} minHeight={100} isVisible={selected} />
-    <Handle type="target" position={Position.Top} />
+    <CustomHandle handleType="target" position={Position.Top} data={data}></CustomHandle>
     <div>
     title: <strong>{localTitle}</strong><br>
     <div class="storynode__content">
       {@html localContent}
     </div>
     </div>
-    <Handle type="source" position={Position.Bottom} />
+    <div>
+      <CustomHandle handleType="source" position={Position.Bottom} data={data}></CustomHandle>
+  </div>
   </div>
 
   <style>

--- a/src/routes/VariablePanel.svelte
+++ b/src/routes/VariablePanel.svelte
@@ -1,0 +1,188 @@
+<script lang="ts">
+	import { get, writable, type Writable } from "svelte/store";
+    import { Button, AccordionItem, Accordion, Radio, Select, Label, Input, CloseButton, Heading, P, A, Mark, Secondary, Table, TableBody, TableBodyCell, TableBodyRow, TableHead, TableHeadCell } from 'flowbite-svelte';
+
+    type Variable = {
+        name: Writable<string>;
+        type: Writable<string>;
+        declaredValue: Writable<any>;
+        currentValue: Writable<any>;
+        isEdited: boolean;
+    }
+
+    export let variables: Writable<Array<Variable>> = writable([]);
+
+    let selectedOption: string;
+    export let visible: boolean = true;
+
+    let newName: string;
+    let newValue: any;
+    let selectedRadio: string;
+    let isEdited: boolean = false;
+
+
+    function createVariable(name: string, type: string, declaredValue: any){
+        return {
+            name: writable(name),
+            type: writable(type),
+            declaredValue: writable(declaredValue),
+            currentValue: writable(declaredValue),
+            isEdited: false
+        }
+        }
+
+    variables.update((currentArray) => {
+		currentArray.push(createVariable("playerName","string","Player"));
+		return currentArray;
+	});
+
+    function declareVariable(){
+        if(selectedOption == "radio"){
+            newValue = selectedRadio;
+        }
+        variables.update((currentArray) => {
+		currentArray.push(createVariable(newName,selectedOption,newValue));
+		return currentArray;
+	});
+
+    }
+
+    function editVariable(variable: Variable){
+        variable.name.set(newName);
+        variable.type.set(selectedOption);
+        variable.declaredValue.set(newValue);
+        variable.isEdited = false;
+        isEdited = false;
+        
+    }
+
+    function deleteVariable(variable: Variable){
+        variables.update(currentArray => {
+            return currentArray.filter(v => v !== variable);
+        });
+    }
+
+
+</script>
+
+{#if visible == false}
+<div class="panelButton">
+<button style="background-color: rgb(235 79 39);
+    font-size: 25px;
+    border-radius: 15px;
+    width: 50px;
+    height: 50px;" on:click={() => (visible = true)}>+</button>
+    </div>
+{:else}
+<div class="variable__panel">
+    <Accordion>
+        <AccordionItem open>
+        <span slot="header"><Heading tag="h5">Variables</Heading></span>
+        <Table striped={true}>
+            <TableHead>
+                <TableHeadCell>Variable name</TableHeadCell>
+                <TableHeadCell>Variable type</TableHeadCell>
+                <TableHeadCell>Value</TableHeadCell>
+            </TableHead>
+            
+            <TableBody tableBodyClass="divide-y">
+    {#each get(variables) as variable}
+    <TableBodyRow>
+        {#if !variable.isEdited}
+        <TableBodyCell>{get(variable.name)}</TableBodyCell>
+        <TableBodyCell>{get(variable.type)}</TableBodyCell>
+        <TableBodyCell>{get(variable.currentValue)}</TableBodyCell>
+        <TableBodyCell>
+          <a class="font-medium text-primary-600 hover:underline dark:text-primary-500" on:click={() => {
+            isEdited = true;
+            variable.isEdited = true;
+            newName = get(variable.name);
+            selectedOption = get(variable.type);
+            newValue = get(variable.declaredValue);
+          }}>Edit</a>
+        </TableBodyCell>
+        <TableBodyCell>
+            <a class="font-medium text-primary-600 hover:underline dark:text-primary-500" on:click={() => deleteVariable(variable)}>Delete</a>
+          </TableBodyCell>
+          {:else}
+        <TableBodyCell><Label for="small-input">Variable name: </Label><Input id="variableName" size="sm" style="" type="text" bind:value={newName}/></TableBodyCell>
+        <TableBodyCell><Label for="small-input">Variable type: </Label>
+            <Select class="mt-2" id="variableType" style="" bind:value={selectedOption}>
+                <option value="text" selected>word</option>
+                <option value="number">number</option>
+                <option value="radio">true/false</option>
+            </Select></TableBodyCell>
+            <TableBodyCell>
+                <Label for="small-input">Value: </Label>
+    {#if selectedOption == "radio"}
+    <label>True </label><Radio checked={true} name="variableValue" value="true" bind:group={selectedRadio}/><label>False </label><Radio name="variableValue" value="false" bind:group={selectedRadio}/>
+    {:else if selectedOption == "text"}
+    <Input id="variableValue" name="variableValue" style="" type="text" bind:value={newValue}/>
+    {:else}
+    <Input id="variableValue" name="variableValue" style="" type="number" bind:value={newValue}/>
+    {/if}
+            </TableBodyCell>
+        <TableBodyCell>
+          <a class="font-medium text-primary-600 hover:underline dark:text-primary-500" on:click={() => editVariable(variable)}>Save</a>
+        </TableBodyCell>
+          {/if}
+      </TableBodyRow>
+    {/each}
+    </TableBody>
+    </Table>
+</AccordionItem>
+{#if !isEdited}
+    <AccordionItem tag="h2">
+        <span slot="header"> + Declare new variable</span>
+    <Label for="small-input">Variable name: </Label><Input id="variableName" size="sm" style="width: 30%; display: inline-block;" type="text" bind:value={newName}/>
+    <Label for="small-input">Variable type: </Label>
+    <Select class="mt-2" id="variableType" style="width: 35%; display: inline-block;" bind:value={selectedOption}>
+        <option value="text" selected>word</option>
+        <option value="number">number</option>
+        <option value="radio">true/false</option>
+    </Select>
+    <Label for="small-input">Value: </Label>
+    {#if selectedOption == "radio"}
+    <label>True </label><Radio checked={true} name="variableValue" value="true" bind:group={selectedRadio}/><label>False </label><Radio name="variableValue" value="false" bind:group={selectedRadio}/>
+    {:else if selectedOption == "text"}
+    <Input id="variableValue" name="variableValue" style="width: 30%;" type="text" bind:value={newValue}/>
+    {:else}
+    <Input id="variableValue" name="variableValue" style="width: 30%;" type="number" bind:value={newValue}/>
+    {/if}
+    <br>
+    <Button on:click={declareVariable}>Declare new variable</Button>
+</AccordionItem>
+{/if}
+    </Accordion>
+    <button style="position: absolute;
+    color: rgb(238, 238, 238);
+    background-color: rgb(43 59 84);
+    font-weight: 800;
+    padding: 10px;
+    width: 100%;
+    text-align: center;
+" on:click={() => (visible = false)}>X Close</button>
+  </div>
+{/if}
+  <style>
+    .variable__panel {
+    position: absolute;
+    right: 10px;
+    top: 20%;
+    z-index: 10000000;
+    font-size: 12px;
+    background-color: #282828;
+    width: 35%;
+    height: auto;
+}
+    .panelButton {
+    position: absolute;
+    top: 70px;
+    right: 1px;
+    z-index: 100000000000000000000000;
+    color: #eee !important;
+    text-align: center;
+}
+
+
+  </style> 

--- a/src/routes/VariablePanel.svelte
+++ b/src/routes/VariablePanel.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
 	import { get, writable, type Writable } from "svelte/store";
     import { Button, AccordionItem, Accordion, Radio, Select, Label, Input, CloseButton, Heading, P, A, Mark, Secondary, Table, TableBody, TableBodyCell, TableBodyRow, TableHead, TableHeadCell } from 'flowbite-svelte';
-    import  isGlobalMode  from "./+page.svelte";
-    import { type Variable } from "./stores";
+    import { isGlobalMode, type Variable } from "./stores";
     import { variables } from "./stores";
 
     let selectedOption: string;
@@ -92,12 +91,12 @@
             </TableHead>
             
             <TableBody tableBodyClass="divide-y">
-    {#each get(variables) as variable}
+    {#each $variables as variable}
     <TableBodyRow>
         {#if !get(variable.isEdited) || !isEdited}
         <TableBodyCell>{get(variable.name)}</TableBodyCell>
         <TableBodyCell>{get(variable.type)}</TableBodyCell>
-        {#if !isGlobalMode}
+        {#if !$isGlobalMode}
         <TableBodyCell>{get(variable.currentValue)}</TableBodyCell>
         {:else}
         <TableBodyCell>{get(variable.declaredValue)}</TableBodyCell>

--- a/src/routes/stores.ts
+++ b/src/routes/stores.ts
@@ -1,9 +1,30 @@
-import { writable } from "svelte/store";
+import { writable, type Writable } from "svelte/store";
 import type { Node } from '@xyflow/svelte'; 
 
 type NodeReference = {
   nodeRef: HTMLDivElement | null;
 };
+
+export type Variable = {
+  name: Writable<string>;
+  type: Writable<string>;
+  declaredValue: Writable<any>;
+  currentValue: Writable<any>;
+  isEdited: Writable<boolean>;
+}
+
+export type Condition = {
+  number: number;
+  var1Type: string;
+  var1: any;
+  comparison: string;
+  var2Type: string;
+  var2: any;
+  funcArgs1: Array<any>;
+  funcArgs2: Array<any>;
+  logicOp?: string;
+
+}
 
 
 let lastId = 0;
@@ -37,5 +58,8 @@ export const nodes = writable<Node[]>([
 export const nodeRefs = writable<NodeReference[]>([]);
 
 export const edges = writable([]);
+
+export let variables: Writable<Array<Variable>> = writable([]);
+export let conditions: Writable<Array<Condition>> = writable([]);
 
 

--- a/src/routes/stores.ts
+++ b/src/routes/stores.ts
@@ -1,5 +1,5 @@
 import { writable, type Writable } from "svelte/store";
-import type { Node } from '@xyflow/svelte';
+import { getIncomers, type Edge, type Node } from '@xyflow/svelte';
 
 type NodeReference = {
   nodeRef: HTMLDivElement | null;
@@ -34,35 +34,38 @@ function getNextId(): number {
   return lastId;
 }
 
-export function createNode(type: string, x: number, y: number, title: string, color: string, delta: any, content: string): Node {
+export function createNode(type: string, x: number, y: number, color: string, delta: any, content: string, title?: string): Node {
+  const newId = `${getNextId()}`;
   return {
-    id: `${getNextId()}`,
+    id: newId,
     type,
     position: { x, y },
     data: {
       title: writable(title),
       color: writable(color),
       delta: writable(delta),
-      content: writable(content)
+      content: writable(content),
+      nodeId: newId,
+      outgoers: null
     }
   };
 }
 
 export const nodes = writable<Node[]>([ 
-  createNode('story-node', 100, 100, 'New Node1', '#ffffff', {ops: [
+  createNode('story-node', 100, 100, '#ffffff', {ops: [
     { insert: 'aaaaa'}
-  ]},'aaaaa'), 
-  createNode('choice-node', 200, 200, 'New Node2', '#454545', {}, '')
+  ]},'aaaaa', 'New Node1'), 
+  createNode('choice-node', 200, 200, '#454545', {ops: [
+    { insert: 'How could I lie to you?'}
+  ]}, 'How could I lie to you?')
 ]);
 
 export const nodeRefs = writable<NodeReference[]>([]);
-
-export const edges = writable([]);
+export const edges = writable<Edge[]>([]);
 
 export let variables: Writable<Array<Variable>> = writable([]);
 export let conditions: Writable<Array<Condition>> = writable([]);
 export let focusedNodeContent: Writable<string> = writable("");
 export let isGlobalMode: Writable<boolean> = writable(true);
-
 
 

--- a/src/routes/stores.ts
+++ b/src/routes/stores.ts
@@ -1,6 +1,10 @@
 import { writable } from "svelte/store";
 import type { Node } from '@xyflow/svelte'; 
 
+type NodeReference = {
+  nodeRef: HTMLDivElement | null;
+};
+
 
 let lastId = 0;
 
@@ -30,31 +34,7 @@ export const nodes = writable<Node[]>([
   createNode('story-node', 200, 200, 'New Node2', '#eeeeee', {}, '')
 ]);
 
-
-function addNode() {
-  nodes.subscribe(allNodes => {
-    const newNode = createNode(
-      'story-node',    
-      100,             
-      100,             
-      'New Node',      
-      '#ffffff',
-      {},      
-      ''               
-    );
-
-    nodes.set([
-      ...allNodes,
-      {
-        ...newNode,
-        position: {
-          x: newNode.position.x + 100,
-          y: newNode.position.y + 100
-        }
-      }
-    ]);
-  });
-}
+export const nodeRefs = writable<NodeReference[]>([]);
 
 export const edges = writable([]);
 

--- a/src/routes/stores.ts
+++ b/src/routes/stores.ts
@@ -1,5 +1,5 @@
 import { writable, type Writable } from "svelte/store";
-import type { Node } from '@xyflow/svelte'; 
+import type { Node } from '@xyflow/svelte';
 
 type NodeReference = {
   nodeRef: HTMLDivElement | null;
@@ -52,7 +52,7 @@ export const nodes = writable<Node[]>([
   createNode('story-node', 100, 100, 'New Node1', '#ffffff', {ops: [
     { insert: 'aaaaa'}
   ]},'aaaaa'), 
-  createNode('story-node', 200, 200, 'New Node2', '#eeeeee', {}, '')
+  createNode('choice-node', 200, 200, 'New Node2', '#454545', {}, '')
 ]);
 
 export const nodeRefs = writable<NodeReference[]>([]);
@@ -61,5 +61,8 @@ export const edges = writable([]);
 
 export let variables: Writable<Array<Variable>> = writable([]);
 export let conditions: Writable<Array<Condition>> = writable([]);
+export let focusedNodeContent: Writable<string> = writable("");
+export let isGlobalMode: Writable<boolean> = writable(true);
+
 
 


### PR DESCRIPTION
- Created a variable panel, which stores and displays all variables used in dialogues. _Variables must be first declared in the panel to appear in functional lines in edit node mode._ Variables can be edited (however, the edited value only changes the _declaredValue_ = the value that will be generated in _declare_ block in yarn).
- Implemented following variable changes in the currently selected node (the panel reads the node content, looks for set functional lines, and updates itself based on found changes). **It does not work fully as intended - there are still errors that need to be fixed in future versions.**
- Implemented adding functional lines to node's content - _set, if, elseif and else_ statements in yarn. The user chooses the functional line type, then sets variables, values and comparisons and adds the line generated with the given input. Enables to join many separate conditions. **Still requires detailed error checks.**
- Implemented choice nodes with all necessary features - adding nodes, changing the background colour, and adding conditions.
- Enabled adding nodes of both types after right-clicking the pane.
- Applied rule to connecting nodes: each node can either connect to one story node or several choice nodes.
- Enabled deleting edges on left-click.